### PR TITLE
Run `mypy` on `src/` automatically

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
       run: uv run flake8 src/ tests/
     
     - name: Run mypy
-      run: uv run mypy src/
+      run: uv run mypy
     
     - name: Run tests with pytest
       run: uv run pytest --cov=src --cov-report=xml --cov-report=term-missing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,7 @@ exclude = [
 ]
 
 [tool.mypy]
+files = ["src"]
 python_version = "3.9"
 warn_return_any = true
 warn_unused_configs = true


### PR DESCRIPTION
Before:

```shell
$ uv run mypy
usage: mypy [-h] [-v] [-V] [more options; see below]
            [-m MODULE] [-p PACKAGE] [-c PROGRAM_TEXT] [files ...]
mypy: error: Missing target module, package, files, or command.
```

After:

```shell
$ uv run mypy
Success: no issues found in 2 source files
```