### PR TITLE
Simplify unsupported provider checking

### DIFF
--- a/src/langchaingang/__init__.py
+++ b/src/langchaingang/__init__.py
@@ -96,16 +96,9 @@ def get_chat_model(provider_name: str, **kwargs: Any) -> BaseChatModel:
     <langchain_ollama.ChatOllama object at 0x7f8b4c177790>
     """
 
-    if not provider.is_supported(provider_name):
-        raise ValueError(f"Unsupported provider: {provider_name}")
-
     chat_model_class = provider.get_chat_model_class(provider_name)
-
     if chat_model_class is None:
-        raise ImportError(
-            f"Provider '{provider_name}' is not available."
-            " Please install the required dependencies."
-        )
+        raise ValueError(f"Unsupported provider: {provider_name}")
 
     # Inject provider-specific defaults
     if provider_name == "bedrock":

--- a/src/langchaingang/provider.py
+++ b/src/langchaingang/provider.py
@@ -39,12 +39,16 @@ def is_supported(provider_name: str) -> bool:
     return provider_name in _get_dict()
 
 
-def get_chat_model_class(provider_name: str) -> type[BaseChatModel]:
+def get_chat_model_class(provider_name: str) -> type[BaseChatModel] | None:
     """
     Get the LangChain chat model class for a given provider name.
+
+    Returns a subclass of `BaseChatModel` or `None` if the provider is not
+    supported.
     """
 
-    return _get_dict()[provider_name]
+    provider_dict = _get_dict()
+    return provider_dict.get(provider_name)
 
 
 def get_list() -> list[str]:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -41,17 +41,6 @@ def test_get_chat_model_unsupported_provider():
 
 @patch("langchaingang.provider.get_chat_model_class")
 @patch("langchaingang.provider.is_supported")
-def test_get_chat_model_import_error(mock_is_supported, mock_get_class):
-    """Test error handling when provider class is not available."""
-    mock_is_supported.return_value = True
-    mock_get_class.return_value = None
-
-    with pytest.raises(ImportError, match="Provider 'test_provider' is not available"):
-        langchaingang.get_chat_model("test_provider")
-
-
-@patch("langchaingang.provider.get_chat_model_class")
-@patch("langchaingang.provider.is_supported")
 def test_get_chat_model_bedrock_parameter_conversion(mock_is_supported, mock_get_class):
     """Test that Bedrock model parameter is converted to model_id."""
     mock_is_supported.return_value = True


### PR DESCRIPTION
- Just check if the provider is supported, and raise an error if not
- Remove the import error check, since it's not needed
- Fixes a pyright error about the provider class being None check never being reachable